### PR TITLE
Update README.md to fix an incorrect arch spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Now that the kernel is updated you can install Docker.
 
 1. Add the following line to the bottom of your `/etc/apt/sources.list`
 ```
-deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+deb [arch=arm64] https://download.docker.com/linux/ubuntu xenial stable
 ```
 2. Update the package lists
 ```


### PR DESCRIPTION
arch=amd64 is incorrect for the Tx2, Tx2 is arm based. Caused my install to fail